### PR TITLE
Clearer example of SCANFOR text

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ The command returns a CPF9898 excape message if value not found. Otherwise a CPF
 The following example scans the outfile log in file QTEMP/STDOUTQSH for a file named test.txt: 
 
  ```
-      QSHLOGSCAN SCANFOR('test.txt')   
+      QSHLOGSCAN SCANFOR('successfully')   
       EXACTMATCH(*YES)         
 ```      
 


### PR DESCRIPTION
Users are seeing "test.txt" and thinking it's a file to be searched. I've changed the text to "successfully" as a clearer example that it's a string to be searched FOR.